### PR TITLE
fix(app): fix version flag missing in NamedFlagSetOptions help output

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -217,6 +217,7 @@ func (app *App) buildCommand() {
 
 		if app.options != nil {
 			fss = typed.Flags()
+			fs = fss.FlagSet("global")
 		}
 
 		for _, f := range fss.FlagSets {


### PR DESCRIPTION
1. Ensure fs variable points to correct FlagSet after NamedFlagSets reassignment so version flag appears in help output.